### PR TITLE
Correct documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This repository contains code accompanying the paper [**Towards multi-spatiotemporal-scale generalized PDE modeling**](https://arxiv.org/abs/2209.15616), and as such we hope this serves as a starting point for future PDE surrogate learning research.
 We have imported models from [**Clifford neural layers for PDE modeling**](https://arxiv.org/abs/2209.04934) and [**Geometric Clifford Algebra Networks**](https://arxiv.org/abs/2302.06594).
 
-For details about usage please see [documentation](https://microsoft.github.io/pdearena).
+For details about usage please see [documentation](https://pdearena.github.io/pdearena/).
 If you have any questions or suggestions please open a [discussion](https://github.com/microsoft/pdearena/discussions). If you notice a bug, please open an [issue](https://github.com/microsoft/pdearena/issues).
 
 ## Citation


### PR DESCRIPTION
super minor, just corrects the doc link to point to the newer(?) pdearena webpage. I get a 404 when trying to visit the old link.